### PR TITLE
Use default value from spec in request scope.

### DIFF
--- a/lib/swagger-n.js
+++ b/lib/swagger-n.js
@@ -29,6 +29,9 @@ function castParam(req, spec) {
 		return;
 	}
 
+	// Set default value from spec
+	req[scope][name] = req[scope][name] || spec.default;
+
 	req.swagger[scope] = req.swagger[scope] || {};
 
 	var param = req[scope][name];


### PR DESCRIPTION
This will pull the default value from the spec and set it in the request scope. I needed this so that the value would flow into `req.params`.
